### PR TITLE
allow host with protocol (ldap, ldaps, ldapi)

### DIFF
--- a/src/lualdap.c
+++ b/src/lualdap.c
@@ -1019,9 +1019,15 @@ static int lualdap_open_simple (lua_State *L) {
 	lualdap_setmeta (L, LUALDAP_CONNECTION_METATABLE);
 	conn->version = 0;
 #if defined(LDAP_API_FEATURE_X_OPENLDAP) && LDAP_API_FEATURE_X_OPENLDAP >= 20300
-	host_with_schema = malloc(strlen(host) + 8);
-	strcpy(host_with_schema, "ldap://");
-	strcat(host_with_schema, host);
+	host_with_schema = (char*) host;
+	if (strlen(host_with_schema)<8 || strncmp(host_with_schema, "ldap", 4)!=0
+		||	(	strncmp(host_with_schema+4, "://", 3)!=0
+			&&	strncmp(host_with_schema+5, "://", 3)!=0)
+	) {
+		host_with_schema = malloc(strlen(host) + 8);
+		strcpy(host_with_schema, "ldap://");
+		strcat(host_with_schema, host);
+	}
 	err = ldap_initialize(&conn->ld, host_with_schema);
 	free(host_with_schema);
 	host_with_schema = NULL;


### PR DESCRIPTION
Hi! I’m not very experienced with C… The idea here is to allow “host” to have a value like “ldap://…”, or “ldaps://…”, or “ldapi://…” (I’m particularly interested in the latter). In such a case, an additional “ldap://” should not be prepended.