### PR TITLE
Makefile: add package_string rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 N= LuaLDAP
 T= lualdap
 V= 1.2.4-rc1
+PACKAGE_STRING=$(N) $(V)
 CONFIG= ./config
 
 include $(CONFIG)
@@ -27,7 +28,7 @@ ifdef JUNITXML
 override BUSTEDFLAGS := $(BUSTEDFLAGS) --output=junit -Xoutput $(REPORT_DIR)/report.xml
 endif
 
-override CPPFLAGS := -DPACKAGE_STRING="\"$(N) $(V)\"" -DLUA_C89_NUMBERS -I$(LUA_INCDIR) -I$(LDAP_INCDIR) -I$(LBER_INCDIR) -I$(COMPAT_DIR) $(CPPFLAGS)
+override CPPFLAGS := -DPACKAGE_STRING="\"$(PACKAGE_STRING)\"" -DLUA_C89_NUMBERS -I$(LUA_INCDIR) -I$(LDAP_INCDIR) -I$(LBER_INCDIR) -I$(COMPAT_DIR) $(CPPFLAGS)
 
 ifeq ($(LUA_VERSION),5.0)
 COMPAT_O= $(COMPAT_DIR)/compat-5.1.o
@@ -55,3 +56,9 @@ endif
 
 $(REPORT_DIR):
 	mkdir -p $@
+
+package_string:
+# useful on custom builds, like in Debian that doesn't use directly make to
+# build the project. So it can be used like
+# -DPACKAGE_STRING="\"$(shell make package_string)\""
+	@echo "$(PACKAGE_STRING)"


### PR DESCRIPTION
allows getting the proper value when building without the original Makefile process. Like we do in Debian, using dh_lua debhelper tool