### PR TITLE
Add scope="subtree" to search example in manual

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -215,7 +215,7 @@ local ld = assert (lualdap.open_simple ("ldap.server",
                 "mydn=manoeljoaquim,ou=people,dc=ldap,dc=world",
                 "mysecurepassword"))
 
-for dn, attribs in ld:search { base = "ou=people,dc=ldap,dc=world" } do
+for dn, attribs in ld:search { base = "ou=people,dc=ldap,dc=world" , scope = "subtree" } do
     io.write (string.format ("\t[%s]\n", dn))
     for name, values in pairs (attribs) do
         io.write ("["..name.."] : ")


### PR DESCRIPTION
I was also bitten by trying to get this working based on the example code and wondering what I'd done wrong...